### PR TITLE
Dockerfile: add ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Jochen Schalanda <jochen+docker@schalanda.name>
 
 ENV PROSODY_VERSION 0.12.4-r1
 
-RUN apk add --no-cache bash "prosody=${PROSODY_VERSION}"
+RUN apk add --no-cache bash ca-certificates "prosody=${PROSODY_VERSION}"
 RUN mkdir -p /etc/prosody/conf.d /usr/local/lib/prosody/modules
 
 COPY prosody.cfg.lua /etc/prosody/prosody.cfg.lua


### PR DESCRIPTION
Wihtout this, prosody will refuse s2s connections as it doesn't trust other services certificates, e.g.:

```
prosody s2sout7cd2004edfa0           warn    Forbidding insecure connection to/from room.peeko.chat because its certificate is not trusted
prosody s2sout7cd2004edfa0     warn    Forbidding insecure connection to/from room.peeko.chat because its certificate is not trusted
prosody s2sout7cd2004edfa0           info    Outgoing s2s stream roobre.es->room.peeko.chat closed: Your server's certificate is not trusted
prosody s2sout7cd2004edfa0           info    Sending error replies for 1 queued stanzas because of failed outgoing connection to room.peeko.chat
prosody s2sout7cd1fff2b910           warn    Forbidding insecure connection to/from conference.prosody.im because its certificate is not trusted
prosody s2sout7cd1fff2b910     warn    Forbidding insecure connection to/from conference.prosody.im because its certificate is not trusted
prosody s2sout7cd1fff2b910           info    Outgoing s2s stream roobre.es->conference.prosody.im closed: Your server's certificate is not trusted
prosody s2sout7cd1fff2b910           info    Sending error replies for 1 queued stanzas because of failed outgoing connection to conference.prosody.im
prosody s2sout7cd1fff366f0           info    Stream encrypted (TLSv1.3 with TLS_AES_256_GCM_SHA384)
prosody s2sout7cd1fff366f0           warn    Forbidding insecure connection to/from conference.siacs.eu because its certificate is not trusted
prosody s2sout7cd1fff366f0     warn    Forbidding insecure connection to/from conference.siacs.eu because its certificate is not trusted
prosody s2sout7cd1fff366f0           info    Outgoing s2s stream roobre.es->conference.siacs.eu closed: Your server's certificate is not trusted
prosody s2sout7cd1fff366f0           info    Sending error replies for 2 queued stanzas because of failed outgoing connection to conference.siacs.eu
prosody s2sout7cd1fff355a0           info    Stream encrypted (TLSv1.3 with TLS_AES_128_GCM_SHA256)
prosody s2sout7cd2004e85a0           info    Stream encrypted (TLSv1.3 with TLS_AES_128_GCM_SHA256)
prosody s2sout7cd2004e85a0           warn    Forbidding insecure connection to/from dino.im because its certificate is not trusted
prosody s2sout7cd2004e85a0     warn    Forbidding insecure connection to/from dino.im because its certificate is not trusted
prosody s2sout7cd2004e85a0           info    Outgoing s2s stream roobre.es->dino.im closed: Your server's certificate is not trusted
prosody s2sout7cd2004e85a0           info    Sending error replies for 2 queued stanzas because of failed outgoing connection to dino.im
prosody s2sout7cd1fff355a0           warn    Forbidding insecure connection to/from conference.prosody.im because its certificate is not trusted
prosody s2sout7cd1fff355a0     warn    Forbidding insecure connection to/from conference.prosody.im because its certificate is not trusted
prosody s2sout7cd1fff355a0           info    Outgoing s2s stream roobre.es->conference.prosody.im closed: Your server's certificate is not trusted
prosody s2sout7cd1fff355a0           info    Sending error replies for 2 queued stanzas because of failed outgoing connection to conference.prosody.im
prosody s2sout7cd20051a440           info    Stream encrypted (TLSv1.3 with TLS_AES_256_GCM_SHA384)
prosody s2sout7cd20051a440           warn    Forbidding insecure connection to/from room.peeko.chat because its certificate is not trusted
prosody s2sout7cd20051a440     warn    Forbidding insecure connection to/from room.peeko.chat because its certificate is not trusted
prosody s2sout7cd20051a440           info    Outgoing s2s stream roobre.es->room.peeko.chat closed: Your server's certificate is not trusted
prosody s2sout7cd20051a440           info    Sending error replies for 2 queued stanzas because of failed outgoing connection to room.peeko.chat
prosody c2s7cd1fff45e80              info    Client connected
prosody c2s7cd1fff45e80              info    Client disconnected: connection closed
```